### PR TITLE
Fixed nmake issue with create_debug_target

### DIFF
--- a/tools/cmake_utils/xmos_macros.cmake
+++ b/tools/cmake_utils/xmos_macros.cmake
@@ -44,7 +44,7 @@ endmacro()
 ## Creates a debug target for a provided binary
 macro(create_debug_target _EXECUTABLE_NAME)
     add_custom_target(debug_${_EXECUTABLE_NAME}
-      COMMAND xgdb ${_EXECUTABLE_NAME}.xe -ex 'connect' -ex 'connect --xscope' -ex 'run'
+      COMMAND xgdb ${_EXECUTABLE_NAME}.xe -ex "connect" -ex "connect --xscope" -ex "run"
       DEPENDS ${_EXECUTABLE_NAME}.xe
       COMMENT
         "Debug application"


### PR DESCRIPTION
Using single-quotes causes a command parsing error that claims there is an unrecognized option `--xscope`.
It is worth noting that the effective command specified in the `cmake` file does work in PowerShell (using single-quotes) but not in the developer command prompt ("x86 Native Tools Command Prompt for VS 2022"). However, in either case running an `nmake` command such as the below results in an error (when using single-quotes):
``` pwsh
nmake debug_example_freertos_getting_started
```

```output
Debug application
C:\Program Files (x86)\XMOS\XTC\15.1.4\bin\xgdb.EXE: unrecognized option `--xscope''
Use `C:\Program Files (x86)\XMOS\XTC\15.1.4\bin\xgdb.EXE --help' for a complete list of options.
NMAKE : fatal error U1077: '"C:\Program Files (x86)\XMOS\XTC\15.1.4\bin\xgdb.EXE"' : return code '0x1'
Stop.
NMAKE : fatal error U1077: '"C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.33.31629\bin\HostX86\x86\nmake.exe"' : return code '0x2'
Stop.
NMAKE : fatal error U1077: '"C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.33.31629\bin\HostX86\x86\nmake.exe"' : return code '0x2'
Stop.
NMAKE : fatal error U1077: '"C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.33.31629\bin\HostX86\x86\nmake.exe"' : return code '0x2'
Stop.
```