### PR TITLE
Feature/tracealyzer support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -33,3 +33,6 @@
 [submodule "xmos_cmake_toolchain"]
 	path = xmos_cmake_toolchain
 	url = git@github.com:xmos/xmos_cmake_toolchain.git
+[submodule "tracealyzer"]
+	path = modules/drivers/trace/FreeRTOS/tracealyzer
+	url = git@github.com:percepio/TraceRecorderSource.git

--- a/modules/bsp_config/CMakeLists.txt
+++ b/modules/bsp_config/CMakeLists.txt
@@ -20,7 +20,6 @@ if(${CMAKE_SYSTEM_NAME} STREQUAL XCORE_XS3A)
             rtos::freertos
             rtos::drivers::general
             rtos::drivers::audio
-            rtos::drivers::trace
             rtos::drivers::usb
     )
     target_compile_definitions(framework_rtos_board_support_config_xcore_ai_explorer_1V1
@@ -69,7 +68,6 @@ if(${CMAKE_SYSTEM_NAME} STREQUAL XCORE_XS3A)
             rtos::freertos
             rtos::drivers::general
             rtos::drivers::audio
-            rtos::drivers::trace
             rtos::drivers::usb
     )
     target_compile_definitions(framework_rtos_board_support_config_xcore_ai_explorer_2V0

--- a/modules/drivers/trace/CMakeLists.txt
+++ b/modules/drivers/trace/CMakeLists.txt
@@ -8,7 +8,7 @@ if((${CMAKE_SYSTEM_NAME} STREQUAL XCORE_XS3A) OR (${CMAKE_SYSTEM_NAME} STREQUAL 
     )
     target_include_directories(framework_rtos_drivers_trace
         INTERFACE
-            api
+        FreeRTOS/api
     )
     target_link_libraries(framework_rtos_drivers_trace
         INTERFACE

--- a/modules/drivers/trace/CMakeLists.txt
+++ b/modules/drivers/trace/CMakeLists.txt
@@ -2,13 +2,22 @@
 if((${CMAKE_SYSTEM_NAME} STREQUAL XCORE_XS3A) OR (${CMAKE_SYSTEM_NAME} STREQUAL XCORE_XS2A))
     ## Create library target
     add_library(framework_rtos_drivers_trace INTERFACE)
+    file(GLOB TRACEALYZER_SOURCES
+        FreeRTOS/tracealyzer/*.c
+        FreeRTOS/tracealyzer/streamports/XMOS_xScope/*.c
+        FreeRTOS/tracealyzer/kernelports/FreeRTOS/*.c
+    )
     target_sources(framework_rtos_drivers_trace
         INTERFACE
             FreeRTOS/ASCII/ascii_trace.c
+            ${TRACEALYZER_SOURCES}
     )
     target_include_directories(framework_rtos_drivers_trace
         INTERFACE
         FreeRTOS/api
+        FreeRTOS/tracealyzer/include
+        FreeRTOS/tracealyzer/streamports/XMOS_xScope/include
+        FreeRTOS/tracealyzer/kernelports/FreeRTOS/include
     )
     target_link_libraries(framework_rtos_drivers_trace
         INTERFACE

--- a/modules/drivers/trace/CMakeLists.txt
+++ b/modules/drivers/trace/CMakeLists.txt
@@ -23,6 +23,10 @@ if((${CMAKE_SYSTEM_NAME} STREQUAL XCORE_XS3A) OR (${CMAKE_SYSTEM_NAME} STREQUAL 
         INTERFACE
             rtos::FreeRTOS::FreeRTOS_SMP
     )
+    target_compile_definitions(framework_rtos_drivers_trace
+        INTERFACE
+            portBASE_TYPE=int
+    )
 
     ## Create an alias
     add_library(rtos::drivers::trace ALIAS framework_rtos_drivers_trace)

--- a/modules/drivers/trace/FreeRTOS/ASCII/ascii_trace.c
+++ b/modules/drivers/trace/FreeRTOS/ASCII/ascii_trace.c
@@ -53,11 +53,11 @@ void traceFreeRTOS_to_xscope(char* fmt, ...)
 	char * strArg;
 	va_list args;
 
-	unsigned char buf[ xcoretraceconfigXSCOPE_TRACE_BUFFER ];
-	unsigned char *end = &buf[ xcoretraceconfigXSCOPE_TRACE_BUFFER - 1 - MAX_XSCOPE_INT_STRING_SIZE ];
+	char buf[ xcoretraceconfigXSCOPE_TRACE_BUFFER ];
+	char *end = &buf[ xcoretraceconfigXSCOPE_TRACE_BUFFER - 1 - MAX_XSCOPE_INT_STRING_SIZE ];
 
 	va_start( args, fmt );
-	unsigned char *p = buf;
+	char *p = buf;
 
 	while( *fmt )
 	{
@@ -151,7 +151,7 @@ void traceFreeRTOS_to_xscope(char* fmt, ...)
 	    }
 		fmt++;
 	}
-	xscope_core_bytes( FREERTOS_TRACE, p - buf , buf );
+	xscope_core_bytes( FREERTOS_TRACE, p - buf , (unsigned char*)buf );
 
 	va_end(args);
 }

--- a/modules/drivers/trace/FreeRTOS/api/xcore_trace.h
+++ b/modules/drivers/trace/FreeRTOS/api/xcore_trace.h
@@ -4,12 +4,38 @@
 #ifndef XCORE_TRACE_H_
 #define XCORE_TRACE_H_
 
-#if ENABLE_RTOS_XSCOPE_TRACE == 1
+/* List of available trace modes */
+#define TRACE_MODE_DISABLED                     0
+#define TRACE_MODE_XSCOPE_ASCII                 1
+#define TRACE_MODE_TRACEALYZER_STREAMING        2
 
+/* Set the desired trace mode. To be set in application-level configuration */
+#ifndef USE_TRACE_MODE
+#define USE_TRACE_MODE                          TRACE_MODE_DISABLED
+#endif
+
+#if (USE_TRACE_MODE != TRACE_MODE_DISABLED)
 #include "FreeRTOSConfig.h"
 #if configUSE_TRACE_FACILITY == 0
 #error configUSE_TRACE_FACILITY must be enabled to trace
 #endif
+
+#if (configGENERATE_RUN_TIME_STATS == 0)
+#error configGENERATE_RUN_TIME_STATS must be enabled to trace
+#endif
+#endif /* (USE_TRACE_MODE != TRACE_MODE_DISABLED) */
+
+/* Enable required define for xscope ascii_trace functionality */
+#define ENABLE_RTOS_XSCOPE_TRACE                (USE_TRACE_MODE == TRACE_MODE_XSCOPE_ASCII)
+
+/* Configuration of the trace mode selected (via USE_TRACE_MODE). */
+#if (USE_TRACE_MODE == TRACE_MODE_TRACEALYZER_STREAMING)
+
+#ifndef __XC__
+#include "trcRecorder.h"
+#endif
+
+#elif (USE_TRACE_MODE == TRACE_MODE_XSCOPE_ASCII)
 
 #include <xscope.h>
 
@@ -19,13 +45,13 @@
 #endif
 
 #ifndef xcoretraceconfigXSCOPE_TRACE_RAW_BYTES
-#define xcoretraceconfigXSCOPE_TRACE_RAW_BYTES          0
+#define xcoretraceconfigXSCOPE_TRACE_RAW_BYTES      0
 #endif
 
 #if( !( __XC__ ) )
 #include "ascii_trace.h"
 #endif /* __XC__ */
 
-#endif /* ENABLE_RTOS_XSCOPE_TRACE */
+#endif /* USE_TRACE_MODE */
 
 #endif /* XCORE_TRACE_H_ */

--- a/tools/cmake_utils/xmos_macros.cmake
+++ b/tools/cmake_utils/xmos_macros.cmake
@@ -42,6 +42,17 @@ macro(create_run_target _EXECUTABLE_TARGET_NAME)
     )
 endmacro()
 
+## Creates a run target for a provided binary. The first argument specifies the file to save to (no extension).
+macro(create_run_xscope_to_file_target _EXECUTABLE_TARGET_NAME _XSCOPE_FILE)
+    add_custom_target(run_xscope_to_file_${_EXECUTABLE_TARGET_NAME}
+      COMMAND xrun --xscope-file ${_XSCOPE_FILE} ${_EXECUTABLE_TARGET_NAME}.xe
+      DEPENDS ${_EXECUTABLE_TARGET_NAME}
+      COMMENT
+        "Run application"
+      VERBATIM
+    )
+endmacro()
+
 ## Creates a debug target for a provided binary
 macro(create_debug_target _EXECUTABLE_TARGET_NAME)
     add_custom_target(debug_${_EXECUTABLE_TARGET_NAME}


### PR DESCRIPTION
Updates for tracealyzer library support

The `trace` library can be set at the cmake project level to one of the following (via a define):
- `USE_TRACE_MODE=TRACE_MODE_XSCOPE_ASCII`
- `USE_TRACE_MODE=TRACE_MODE_TRACEALYZER_STREAMING `

By default, the library is configured to:
- `USE_TRACE_MODE=TRACE_MODE_DISABLED`