### PR TITLE
Feature/device control spi support

### DIFF
--- a/modules/sw_services/device_control/src/device_control.c
+++ b/modules/sw_services/device_control/src/device_control.c
@@ -266,8 +266,8 @@ void device_control_payload_transfer_bidir(device_control_t *ctx,
         else // Read command
         {
             rtos_printf("do_read_command(), requested_resid %d, requested_cmd %d, requested_payload_len %d\n", requested_resid, requested_cmd, requested_payload_len);
-            ret = do_command(ctx, servicer, requested_resid, requested_cmd, &tx_buf[1], requested_payload_len-1);
-            tx_buf[0] = ret;
+            ret = do_command(ctx, servicer, requested_resid, requested_cmd, tx_buf, requested_payload_len);
+            //tx_buf[0] = ret;
             *tx_size = requested_payload_len;
         }
     }
@@ -328,8 +328,8 @@ control_ret_t device_control_payload_transfer(device_control_t *ctx,
             {
                 rtos_printf("Read request for read command %d\n", requested_cmd);
                 // Forward the command to the servicer. Update returned status in the first byte of payload
-                ret = do_command(ctx, servicer, requested_resid, requested_cmd, &payload_buf[1], requested_payload_len-1);
-                payload_buf[0] = ret;
+                ret = do_command(ctx, servicer, requested_resid, requested_cmd, payload_buf, requested_payload_len);
+                //payload_buf[0] = ret;
             }
 
         }

--- a/modules/sw_services/device_control/transport/spi/device_control_spi.c
+++ b/modules/sw_services/device_control/transport/spi/device_control_spi.c
@@ -23,14 +23,14 @@ void device_control_spi_start_cb(rtos_spi_slave_t *ctx,
     spi_slave_xfer_prepare(ctx, spi_xfer_rx_buf, SPI_XFER_RX_SIZE, spi_xfer_tx_buf, SPI_XFER_TX_SIZE);
 
     control_ret_t dc_ret;
-    rtos_printf("Registering SPI device control resources now\n");
+
     dc_ret = device_control_resources_register(device_control_ctx,
                                                pdMS_TO_TICKS(5000));
 
     if (dc_ret != CONTROL_SUCCESS) {
-        rtos_printf("Device control resources failed to register for SPI on tile %d\n", THIS_XCORE_TILE);
+        //rtos_printf("Device control resources failed to register for SPI on tile %d\n", THIS_XCORE_TILE);
     } else {
-        rtos_printf("Device control resources registered for SPI on tile %d\n", THIS_XCORE_TILE);
+        //rtos_printf("Device control resources registered for SPI on tile %d\n", THIS_XCORE_TILE);
     }
     xassert(dc_ret == CONTROL_SUCCESS);
 }


### PR DESCRIPTION
- Remove payload[0] = status update code from device_control to keep it generic and making this the application's responsibility.
- Remove some prints that were causing the application to miss timing.