### PR TITLE
Feature/cmake ninja support

### DIFF
--- a/tools/cmake_utils/xmos_macros.cmake
+++ b/tools/cmake_utils/xmos_macros.cmake
@@ -12,7 +12,7 @@ macro(merge_binaries _OUTPUT_TARGET_NAME _BASE_TARGET _OTHER_TARGET _TILE_NUM_TO
     get_target_property(BASE_TILE_NAME    ${_BASE_TARGET}  NAME)
     get_target_property(OTHER_TILE_NAME   ${_OTHER_TARGET} NAME)
 
-    add_custom_target(${_OUTPUT_TARGET_NAME}
+    add_custom_target(${_OUTPUT_TARGET_NAME} ALL
         COMMAND ${CMAKE_COMMAND} -E make_directory ${OTHER_TILE_NAME}_split
         COMMAND xobjdump --split --split-dir ${OTHER_TILE_NAME}_split ${OTHER_TILE_NAME}.xe
         COMMAND xobjdump ${BASE_TILE_NAME}.xe -r 0,${_TILE_NUM_TO_MERGE},${OTHER_TILE_NAME}_split/image_n0c${_TILE_NUM_TO_MERGE}_2.elf

--- a/tools/cmake_utils/xmos_macros.cmake
+++ b/tools/cmake_utils/xmos_macros.cmake
@@ -21,6 +21,7 @@ macro(merge_binaries _OUTPUT_TARGET_NAME _BASE_TARGET _OTHER_TARGET _TILE_NUM_TO
             ${_BASE_TARGET}
             ${_OTHER_TARGET}
         BYPRODUCTS
+            ${_OUTPUT_TARGET_NAME}.xe
             ${OTHER_TILE_NAME}_split
         WORKING_DIRECTORY
             ${BASE_TILE_DIR}

--- a/tools/cmake_utils/xmos_macros.cmake
+++ b/tools/cmake_utils/xmos_macros.cmake
@@ -22,14 +22,16 @@ macro(merge_binaries _OUTPUT_TARGET_NAME _BASE_TARGET _OTHER_TARGET _TILE_NUM_TO
             ${_OTHER_TARGET}
         BYPRODUCTS
             ${_OUTPUT_TARGET_NAME}.xe
-            ${OTHER_TILE_NAME}_split
         WORKING_DIRECTORY
             ${BASE_TILE_DIR}
         COMMENT
             "Merge tile ${_TILE_NUM_TO_MERGE} of ${_OTHER_TARGET}.xe into ${_BASE_TARGET}.xe to create ${_OUTPUT_TARGET_NAME}.xe"
         VERBATIM
     )
-    set_target_properties(${_OUTPUT_TARGET_NAME} PROPERTIES BINARY_DIR ${BASE_TILE_DIR})
+    set_target_properties(${_OUTPUT_TARGET_NAME} PROPERTIES
+      BINARY_DIR ${BASE_TILE_DIR}
+      ADDITIONAL_CLEAN_FILES "${OTHER_TILE_NAME}_split"
+    )
 endmacro()
 
 ## Creates a run target for a provided binary

--- a/tools/cmake_utils/xmos_macros.cmake
+++ b/tools/cmake_utils/xmos_macros.cmake
@@ -14,8 +14,8 @@ macro(merge_binaries _OUTPUT_TARGET_NAME _BASE_TARGET _OTHER_TARGET _TILE_NUM_TO
 
     add_custom_target(${_OUTPUT_TARGET_NAME} ALL
         COMMAND ${CMAKE_COMMAND} -E make_directory ${OTHER_TILE_NAME}_split
-        COMMAND xobjdump --split --split-dir ${OTHER_TILE_NAME}_split ${OTHER_TILE_NAME}.xe
-        COMMAND xobjdump ${BASE_TILE_NAME}.xe -r 0,${_TILE_NUM_TO_MERGE},${OTHER_TILE_NAME}_split/image_n0c${_TILE_NUM_TO_MERGE}_2.elf
+        COMMAND xobjdump --split --split-dir ${OTHER_TILE_NAME}_split ${OTHER_TILE_NAME}.xe > ${OTHER_TILE_NAME}_split/output.log
+        COMMAND xobjdump ${BASE_TILE_NAME}.xe -r 0,${_TILE_NUM_TO_MERGE},${OTHER_TILE_NAME}_split/image_n0c${_TILE_NUM_TO_MERGE}_2.elf >> ${OTHER_TILE_NAME}_split/output.log
         COMMAND ${CMAKE_COMMAND} -E copy ${BASE_TILE_NAME}.xe ${_OUTPUT_TARGET_NAME}.xe
         DEPENDS
             ${_BASE_TARGET}


### PR DESCRIPTION
In addition to adding support for the Ninja CMake generator, there are two other changes that are being proposed in this PR:

1. Adding the `ALL` option to the `merge_binaries` build target. This will allow for a `make all` command to build all of the final *.XE applications. One concern here was whether or not artifacts that use the same name would have any adverse effects (i.e.  building _program A_ results in an _artifact X_, and building _program B_ also results in an _artifact X_ that may or may not be the same). Ninja's requirement to ensure all byproducts/outputs be uniquely named may be the measure needed to combat this, but additional thought/testing may be in order here.
2. Suppress standard output of the xobjdump commands. My feeling is for successful builds, output should be clear and concise. This is to help visually differentiate between builds that have warnings/errors that may not be colorized or easily spotted in the build output. This suppressed output is instead routed into a log file in case there is a need to inspect it, but errors/warnings from the tool will not be captured here and will only be emitted in the normal build output. This may have a small downside of the error/warning not being shown along-side of the tool's normal standard output. It might be possible to change this behavior by capturing all output to a log file, checking the exit code of the operation and if an error occurred, emit the full contents of the log file to the console during the build operation.