### PR TITLE
Fixed datapartition_mkimage binary handling

### DIFF
--- a/tools/datapartition_mkimage/datapartition_mkimage.c
+++ b/tools/datapartition_mkimage/datapartition_mkimage.c
@@ -9,7 +9,7 @@
 #include <limits.h>
 #include <string.h>
 
-#define VERSION "1.0.0"
+#define VERSION "1.0.1"
 
 // Abstractions for portability
 #ifdef __GNUC__
@@ -542,7 +542,7 @@ int main(int argc, char *argv[])
              * characters, change the mode to binary mode. */
             SETMODE(FILENO(stdin), _O_BINARY);
         } else {
-            FOPEN(in_file, input_files[file_index].filename, "r");
+            FOPEN(in_file, input_files[file_index].filename, "rb");
         }
 
         if (in_file == NULL) {


### PR DESCRIPTION
Binary files provided via the --in-file argument were not opened in binary mode (for Windows systems). This would potentially result in undesired conversion of new line characters or early termination. In such cases, WARNING messages would be emitted indicating unexpected number of bytes written).