### PR TITLE
Reverted to mbedtls 2.16.6

### DIFF
--- a/modules/sw_services/tls_support/CMakeLists.txt
+++ b/modules/sw_services/tls_support/CMakeLists.txt
@@ -2,15 +2,89 @@
 if((${CMAKE_SYSTEM_NAME} STREQUAL XCORE_XS3A) OR (${CMAKE_SYSTEM_NAME} STREQUAL XCORE_XS2A))
     ## Create library target
     add_library(framework_rtos_sw_services_tls INTERFACE)
-    
-    ## Glob mbedtls sources
-    file(GLOB_RECURSE MBEDTLS_SOURCES ${CMAKE_CURRENT_LIST_DIR}/thirdparty/mbedtls/library/*.c )
-    
     target_sources(framework_rtos_sw_services_tls
         INTERFACE
             FreeRTOS/mbedtls_support.c
             thirdparty/port/mbedtls/FreeRTOS/mbedtls_xcore_platform.c
-            ${MBEDTLS_SOURCES}
+            thirdparty/mbedtls/library/aes.c
+            thirdparty/mbedtls/library/aesni.c
+            thirdparty/mbedtls/library/arc4.c
+            thirdparty/mbedtls/library/aria.c
+            thirdparty/mbedtls/library/asn1parse.c
+            thirdparty/mbedtls/library/asn1write.c
+            thirdparty/mbedtls/library/base64.c
+            thirdparty/mbedtls/library/bignum.c
+            thirdparty/mbedtls/library/blowfish.c
+            thirdparty/mbedtls/library/camellia.c
+            thirdparty/mbedtls/library/ccm.c
+            thirdparty/mbedtls/library/chacha20.c
+            thirdparty/mbedtls/library/chachapoly.c
+            thirdparty/mbedtls/library/cipher.c
+            thirdparty/mbedtls/library/cipher_wrap.c
+            thirdparty/mbedtls/library/cmac.c
+            thirdparty/mbedtls/library/ctr_drbg.c
+            thirdparty/mbedtls/library/des.c
+            thirdparty/mbedtls/library/dhm.c
+            thirdparty/mbedtls/library/ecdh.c
+            thirdparty/mbedtls/library/ecdsa.c
+            thirdparty/mbedtls/library/ecjpake.c
+            thirdparty/mbedtls/library/ecp.c
+            thirdparty/mbedtls/library/ecp_curves.c
+            thirdparty/mbedtls/library/entropy.c
+            thirdparty/mbedtls/library/entropy_poll.c
+            thirdparty/mbedtls/library/error.c
+            thirdparty/mbedtls/library/gcm.c
+            thirdparty/mbedtls/library/havege.c
+            thirdparty/mbedtls/library/hkdf.c
+            thirdparty/mbedtls/library/hmac_drbg.c
+            thirdparty/mbedtls/library/md.c
+            thirdparty/mbedtls/library/md2.c
+            thirdparty/mbedtls/library/md4.c
+            thirdparty/mbedtls/library/md5.c
+            thirdparty/mbedtls/library/md_wrap.c
+            thirdparty/mbedtls/library/memory_buffer_alloc.c
+            thirdparty/mbedtls/library/nist_kw.c
+            thirdparty/mbedtls/library/oid.c
+            thirdparty/mbedtls/library/padlock.c
+            thirdparty/mbedtls/library/pem.c
+            thirdparty/mbedtls/library/pk.c
+            thirdparty/mbedtls/library/pk_wrap.c
+            thirdparty/mbedtls/library/pkcs12.c
+            thirdparty/mbedtls/library/pkcs5.c
+            thirdparty/mbedtls/library/pkparse.c
+            thirdparty/mbedtls/library/pkwrite.c
+            thirdparty/mbedtls/library/platform.c
+            thirdparty/mbedtls/library/platform_util.c
+            thirdparty/mbedtls/library/poly1305.c
+            thirdparty/mbedtls/library/ripemd160.c
+            thirdparty/mbedtls/library/rsa.c
+            thirdparty/mbedtls/library/rsa_internal.c
+            thirdparty/mbedtls/library/sha1.c
+            thirdparty/mbedtls/library/sha256.c
+            thirdparty/mbedtls/library/sha512.c
+            thirdparty/mbedtls/library/threading.c
+            thirdparty/mbedtls/library/timing.c
+            thirdparty/mbedtls/library/version.c
+            thirdparty/mbedtls/library/version_features.c
+            thirdparty/mbedtls/library/xtea.c
+            thirdparty/mbedtls/library/certs.c
+            thirdparty/mbedtls/library/pkcs11.c
+            thirdparty/mbedtls/library/x509.c
+            thirdparty/mbedtls/library/x509_create.c
+            thirdparty/mbedtls/library/x509_crl.c
+            thirdparty/mbedtls/library/x509_crt.c
+            thirdparty/mbedtls/library/x509_csr.c
+            thirdparty/mbedtls/library/x509write_crt.c
+            thirdparty/mbedtls/library/x509write_csr.c
+            thirdparty/mbedtls/library/debug.c
+            thirdparty/mbedtls/library/net_sockets.c
+            thirdparty/mbedtls/library/ssl_cache.c
+            thirdparty/mbedtls/library/ssl_ciphersuites.c
+            thirdparty/mbedtls/library/ssl_cli.c
+            thirdparty/mbedtls/library/ssl_cookie.c
+            thirdparty/mbedtls/library/ssl_srv.c
+            thirdparty/mbedtls/library/ssl_ticket.c
+            thirdparty/mbedtls/library/ssl_tls.c
     )
     target_include_directories(framework_rtos_sw_services_tls
         INTERFACE


### PR DESCRIPTION
The update to 2.28.3 causes an exception shortly after the xcore-iot MQTT demo (on branch b3bb4cdca5) connects to the broker or immediately after receipt of the subscribed message.

Further investigation is needed to perform this update.