### PR TITLE
Fix to stop dest_ctrl_buffer being overwritten when xfers on EPs othe…

### DIFF
--- a/modules/sw_services/usb/portable/dcd_xcore.c
+++ b/modules/sw_services/usb/portable/dcd_xcore.c
@@ -175,7 +175,8 @@ static void dcd_xcore_int_handler(rtos_usb_t *ctx,
                     prepare_setup(true);
                     rtos_printf("xfer error - unhandled OUT packet on EP0 (bytes: %d)\n", xfer_len);
                     return;
-                } else if (dest_ctrl_buffer != NULL) {
+                } else {
+                    xassert(dest_ctrl_buffer != NULL); // dest_ctrl_buffer cannot be NULL for ep_addr 0
                     memcpy(dest_ctrl_buffer, intermediate_buffer, xfer_len);
                     dest_ctrl_buffer = NULL;
                 }
@@ -478,7 +479,6 @@ bool dcd_edpt_xfer(uint8_t rhport,
         rtos_printf("xfer %d bytes on %02x\n", total_bytes, ep_addr);
     }
 
-    dest_ctrl_buffer = (is_ep0_output) ? (void *)buffer : NULL;
     dest_ctrl_buffer_len = total_bytes;
 
     /*
@@ -486,6 +486,7 @@ bool dcd_edpt_xfer(uint8_t rhport,
      * assume the CRC16 is to be written to its control buffer.
      */
     if (is_ep0_output) {
+        dest_ctrl_buffer = buffer;
         buffer = (uint8_t *)intermediate_buffer;
     }
 


### PR DESCRIPTION
…r than EP0 are initiated.

I came across this issue when testing control commands sent continuously while the HID Input endpoint was also sending reports every 10ms. The EP0 out xfer sets the dest_ctrl_buffer when starting the EP0 xfer. The HID task then starts a xfer that would set dest_ctrl_buffer to NULL, and when the EP0 xfer completes it would see dest_ctrl_buffer as NULL and the H2D data would not be copied properly.