### PR TITLE
flag RTOS I2S APIs called from the wrong tile

### DIFF
--- a/modules/drivers/i2s/api/rtos_i2s.h
+++ b/modules/drivers/i2s/api/rtos_i2s.h
@@ -148,6 +148,7 @@ struct rtos_i2s_struct{
         volatile size_t required_available_count;
     } recv_buffer;
     uint8_t isr_cmd;
+    uint8_t i2s_tile_no;
 };
 
 #include "rtos_i2s_rpc.h"

--- a/modules/drivers/i2s/src/rtos_i2s.c
+++ b/modules/drivers/i2s/src/rtos_i2s.c
@@ -224,6 +224,7 @@ static size_t i2s_local_rx(rtos_i2s_t *ctx,
     size_t words_remaining = frame_count * (2 * ctx->num_in);
     int32_t *sample_buf_ptr = (int32_t *) i2s_sample_buf;
 
+    xassert(THIS_XCORE_TILE == ctx->i2s_tile_no);
     xassert(words_remaining <= ctx->recv_buffer.buf_size);
     if (words_remaining > ctx->recv_buffer.buf_size) {
         return frames_recvd;
@@ -276,6 +277,7 @@ static size_t i2s_local_tx(rtos_i2s_t *ctx,
     size_t frames_sent = 0;
     size_t words_remaining = frame_count * (2 * ctx->num_out);
 
+    xassert(THIS_XCORE_TILE == ctx->i2s_tile_no);
     xassert(words_remaining <= ctx->send_buffer.buf_size);
     if (words_remaining > ctx->send_buffer.buf_size) {
         return frames_sent;
@@ -327,6 +329,7 @@ void rtos_i2s_start(
         size_t send_buffer_size,
         unsigned interrupt_core_id)
 {
+    xassert(THIS_XCORE_TILE == ctx->i2s_tile_no);
     uint32_t core_exclude_map;
 
     i2s_ctx->mclk_bclk_ratio = mclk_bclk_ratio;
@@ -397,6 +400,7 @@ static void rtos_i2s_init(
     ctx->rpc_config = NULL;
     ctx->rx = i2s_local_rx;
     ctx->tx = i2s_local_tx;
+    ctx->i2s_tile_no = THIS_XCORE_TILE;
 
     triggerable_setup_interrupt_callback(ctx->c_i2s_isr.end_b, ctx, RTOS_INTERRUPT_CALLBACK(rtos_i2s_isr));
 

--- a/modules/drivers/i2s/src/rtos_i2s.c
+++ b/modules/drivers/i2s/src/rtos_i2s.c
@@ -329,7 +329,7 @@ void rtos_i2s_start(
         size_t send_buffer_size,
         unsigned interrupt_core_id)
 {
-    xassert(THIS_XCORE_TILE == ctx->i2s_tile_no);
+    xassert(THIS_XCORE_TILE == i2s_ctx->i2s_tile_no);
     uint32_t core_exclude_map;
 
     i2s_ctx->mclk_bclk_ratio = mclk_bclk_ratio;


### PR DESCRIPTION
https://xmosjira.atlassian.net/browse/AP-157


Reading through the issue, what I understand is, we need to have a mechanism to flag an error is the rtos_i2s_slave API functions are called from the wrong tile. I think, ensuring this is the application’s responsibility; perhaps by ensuring that the rtos_i2s_struct handle is only defined on the correct tile in driver_instances.c.

The only way I can think of fixing this in the driver is by making note of the tile on which rtos_i2s_slave_init is called and asserting if the other RTOS I2S slave driver APIs, rtos_i2s_start, rtos_i2s_tx and rtos_i2s_rx are called from the other tile. The assert would fail if

- the application called an rtos_i2s_start, rtos_i2s_tx and rtos_i2s_rx api function from a different tile than rtos_i2s_init() function for the I2S slave

- the application called an rtos_i2s_start, rtos_i2s_tx and rtos_i2s_rx api function from a different tile than rtos_i2s_init() function for the I2S without instantiating the RPC for the I2S master.


This change assumes that the define THIS_XCORE_TILE has been defined by the application. This seems to be a standard requirement since a lot of driver code refers to THIS_XCORE_TILE for debug printing etc.