### PR TITLE
Fix UART test settings and re-enable tests

### DIFF
--- a/modules/drivers/uart/src/rtos_uart_rx.c
+++ b/modules/drivers/uart/src/rtos_uart_rx.c
@@ -2,7 +2,6 @@
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 
 #define DEBUG_UNIT RTOS_UART_RX
-#define DEBUG_PRINT_ENABLE_RTOS_UART_RX 1
 
 #include <xcore/triggerable.h>
 #include <string.h>

--- a/modules/drivers/uart/src/rtos_uart_rx.c
+++ b/modules/drivers/uart/src/rtos_uart_rx.c
@@ -18,7 +18,7 @@ DEFINE_RTOS_INTERRUPT_CALLBACK(rtos_uart_rx_isr, arg)
 
     /* Grab byte received from rx which triggered ISR */
     uint8_t byte = s_chan_in_byte(ctx->c.end_b);
-    
+
     BaseType_t pxHigherPriorityTaskWoken = pdFALSE;
 
     /* We already know the task handle of the receiver so cast to correct type */
@@ -44,6 +44,8 @@ static void uart_rx_error_callback(uart_callback_code_t callback_code, void * ap
 
 static void uart_rx_hil_thread(rtos_uart_rx_t *ctx)
 {
+    rtos_printf("UART Rx on tile %d core %d\n", THIS_XCORE_TILE, rtos_core_id_get());
+
     /* consume token (synch with RTOS driver) */
     (void) s_chan_in_byte(ctx->c.end_a);
 
@@ -80,7 +82,7 @@ static void uart_rx_app_thread(rtos_uart_rx_t *ctx)
             bytes_read += 1;
         } while(ret == UART_BUFFER_OK);
         bytes_read -= 1; /* important as we incremented this for the last read fail too */
-    
+
         if(bytes_read){
             size_t xBytesSent = xStreamBufferSend(ctx->app_byte_buffer, bytes, bytes_read, 0);
 
@@ -149,7 +151,7 @@ void rtos_uart_rx_init(
         uart_rx_error_callback,
         uart_rx_ctx
         );
- 
+
 
     uart_rx_ctx->c = s_chan_alloc();
 
@@ -177,7 +179,7 @@ void rtos_uart_rx_start(
         unsigned interrupt_core_id,
         unsigned priority,
         size_t app_rx_buff_size){
-    
+
     /* Init callbacks & args */
     uart_rx_ctx->app_data = app_data;
     uart_rx_ctx->rx_start_cb = rx_start;

--- a/modules/drivers/uart/src/rtos_uart_tx.c
+++ b/modules/drivers/uart/src/rtos_uart_tx.c
@@ -2,7 +2,6 @@
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 
 #define DEBUG_UNIT RTOS_UART_TX
-#define DEBUG_PRINT_ENABLE_RTOS_UART_TX 1
 
 #include "rtos_uart_tx.h"
 
@@ -21,7 +20,7 @@ static void uart_tx_local_write(
         uart_tx(&ctx->dev, buff[i]);
         rtos_interrupt_unmask_all();
     }
-    
+
     rtos_osal_mutex_put(&ctx->lock);
 }
 
@@ -44,7 +43,7 @@ void rtos_uart_tx_init(
         const uart_parity_t parity,
         const uint8_t stop_bits,
         hwtimer_t tmr){
-    
+
     //uart init
     uart_tx_blocking_init(
             &ctx->dev,

--- a/test/rtos_drivers/hil_add/README.rst
+++ b/test/rtos_drivers/hil_add/README.rst
@@ -11,8 +11,9 @@ Description
 
 The RTOS driver tests are designed to regression test RTOS driver behavior for the following drivers:
 
-- spi
 - qspi_fast_read
+- spi
+- uart
 
 These tests assume that the associated RTOS and HILs used have been verified by their own localized separate testing.
 

--- a/test/rtos_drivers/hil_add/hil_add.cmake
+++ b/test/rtos_drivers/hil_add/hil_add.cmake
@@ -2,7 +2,7 @@
 # Individual tests
 #**********************
 set(SPI_TEST  1)
-set(UART_TEST  0)   # Appears to be broken
+set(UART_TEST  1)
 set(QSPI_FLASH_FAST_READ_TEST 1)
 
 #**********************

--- a/test/rtos_drivers/hil_add/src/app_conf.h
+++ b/test/rtos_drivers/hil_add/src/app_conf.h
@@ -23,7 +23,7 @@
 #define SPI_TEST_BUF_SIZE       4096
 
 #define UART_RX_CORE_MASK       (1 << 2)
-#define UART_RX_ISR_CORE        2
+#define UART_RX_ISR_CORE        3
 #define UART_BAUD_RATE          921600
 
 

--- a/test/rtos_drivers/hil_add/src/individual_tests/uart/uart_test.c
+++ b/test/rtos_drivers/hil_add/src/individual_tests/uart/uart_test.c
@@ -101,7 +101,7 @@ static void start_uart_devices(uart_test_ctx_t *test_ctx)
         rtos_uart_rx_started,
         rtos_uart_rx_complete,
         rtos_uart_rx_error,
-        (1 << UART_RX_ISR_CORE),
+        UART_RX_ISR_CORE,
         appconfSTARTUP_TASK_PRIORITY,
         1024 // Big enough to hold tx_buff[] many times over
         );

--- a/test/rtos_drivers/hil_add/src/main.c
+++ b/test/rtos_drivers/hil_add/src/main.c
@@ -69,17 +69,6 @@ void vApplicationDaemonTaskStartup(void *arg)
         test_printf("SKIP QSPI_FLASH_FAST_READ");
     }
 
-    if (RUN_UART_TESTS) {
-        if (uart_device_tests(rtos_uart_tx_ctx, rtos_uart_rx_ctx, other_tile_c) != 0)
-        {
-            test_printf("FAIL UART");
-        } else {
-            test_printf("PASS UART");
-        }
-    } else {
-        test_printf("SKIP UART");
-    }
-
     if (RUN_SPI_TESTS) {
         if (spi_device_tests(spi_master_ctx, test_spi_device_ctx, spi_slave_ctx, other_tile_c) != 0)
         {
@@ -89,6 +78,17 @@ void vApplicationDaemonTaskStartup(void *arg)
         }
     } else {
         test_printf("SKIP SPI");
+    }
+
+    if (RUN_UART_TESTS) {
+        if (uart_device_tests(rtos_uart_tx_ctx, rtos_uart_rx_ctx, other_tile_c) != 0)
+        {
+            test_printf("FAIL UART");
+        } else {
+            test_printf("PASS UART");
+        }
+    } else {
+        test_printf("SKIP UART");
     }
 
     _Exit(0);


### PR DESCRIPTION
In hil_add tests, the UART ISR core must differ from the core for SPI slave.

Closes https://xmosjira.atlassian.net/browse/AP-257