### PR TITLE
Move to devzone wifi, change ip, ssid and password

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,8 +26,8 @@ pipeline {
         VENV_DIRNAME = ".venv"
         BUILD_DIRNAME = "dist"
         RTOS_TEST_RIG_TARGET = "XCORE-AI-EXPLORER"
-        LOCAL_WIFI_SSID = credentials('bristol-office-test-ssid')
-        LOCAL_WIFI_PASS = credentials('bristol-office-test-wifi-password')
+        LOCAL_WIFI_SSID = credentials('bristol-office-development-wifi-ssid')
+        LOCAL_WIFI_PASS = credentials('bristol-office-development-wifi-password')
     }
     stages {
         stage('Build and Docs') {

--- a/test/rtos_drivers/wifi/src/FreeRTOSIPConfig.h
+++ b/test/rtos_drivers/wifi/src/FreeRTOSIPConfig.h
@@ -46,9 +46,9 @@
 #endif
 
 /* User defined network parameters */
-#define IPconfig_IP_ADDR_OCTET_0    192
-#define IPconfig_IP_ADDR_OCTET_1    168
-#define IPconfig_IP_ADDR_OCTET_2    5
+#define IPconfig_IP_ADDR_OCTET_0    10
+#define IPconfig_IP_ADDR_OCTET_1    0
+#define IPconfig_IP_ADDR_OCTET_2    201
 #define IPconfig_IP_ADDR_OCTET_3    3
 
 #define IPconfig_NET_MASK_OCTET_0   255
@@ -56,9 +56,9 @@
 #define IPconfig_NET_MASK_OCTET_2   255
 #define IPconfig_NET_MASK_OCTET_3   0
 
-#define IPconfig_GATEWAY_OCTET_0     192
-#define IPconfig_GATEWAY_OCTET_1     168
-#define IPconfig_GATEWAY_OCTET_2     5
+#define IPconfig_GATEWAY_OCTET_0     10
+#define IPconfig_GATEWAY_OCTET_1     0
+#define IPconfig_GATEWAY_OCTET_2     201
 #define IPconfig_GATEWAY_OCTET_3     1
 
 #define IPconfig_DNS_SERVER_OCTET_0   8


### PR DESCRIPTION
IT have put together a more robust solution to a permanent test wifi for people to use. This will replace the raspberry pi AP.