### PR TITLE
Remove use of internal Tools API

### DIFF
--- a/modules/rtos_support/src/rtos_interrupt_impl.h
+++ b/modules/rtos_support/src/rtos_interrupt_impl.h
@@ -24,7 +24,7 @@
     .issue_mode single; \
     .cc_top _XCORE_INTERRUPT_PERMITTED(root_function).function,_XCORE_INTERRUPT_PERMITTED(root_function); \
     _XCORE_INTERRUPT_PERMITTED(root_function):; \
-      _XCORE_ENTSP(_XCORE_STACK_ALIGN(5)); \
+      ENTSP_lu6 _XCORE_STACK_ALIGN(5); \
       /* Save CP into SP[4] */ \
       ldaw r11, cp[0]; \
       stw r11, sp[4];  \


### PR DESCRIPTION
This renders this repo compatible with Tools 15.3.1001, proven [here](http://srv-bri-jcim0:8080/blue/organizations/jenkins/XMOS%2Fsw_xvf3800/detail/PR-1351/2/pipeline/1652) where sw_xvf3800 was built with this toolchain.

Part of [VFH-102](https://xmosjira.atlassian.net/browse/VFH-102)



[VFH-102]: https://xmosjira.atlassian.net/browse/VFH-102?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ