### PR TITLE
Use macro for error printouts in host device drivers

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ UNRELEASED
 
   * FIXED: Windows host issue with pre-2013 Visual Studio Compiler and stdbool.h.
   * UPDATED: To tinyusb_src commit c61f5f4, it includes official support for USB test mode.
+  * FIXED: Adopted common format in error printouts of device control host drivers.
 
 3.1.0
 -----

--- a/modules/sw_services/device_control/host/device_access_i2c_rpi.c
+++ b/modules/sw_services/device_control/host/device_access_i2c_rpi.c
@@ -1,4 +1,4 @@
-// Copyright 2016-2023 XMOS LIMITED.
+// Copyright 2016-2024 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 #if USE_I2C && RPI
 
@@ -40,13 +40,12 @@ control_ret_t control_init_i2c(unsigned char i2c_slave_address)
 
   if ((fd = open(devName, O_RDWR)) < 0) {          // Open port for reading and writing
     PRINT_ERROR("Failed to open i2c port: ");
-    perror( "" );
     return CONTROL_ERROR;
   }
 
   if (ioctl(fd, I2C_SLAVE, address) < 0) {          // Set the port options and set the address of the device we wish to speak to
-    PRINT_ERROR("unable to set i2c configuration at address 0x%x: ", address);
-    perror( "" );
+    PRINT_ERROR("Unable to set i2c configuration at address 0x%x: ", address);
+    perror("Error  :");
     return CONTROL_ERROR;
   }
 
@@ -95,7 +94,7 @@ control_write_command(control_resid_t resid, control_cmd_t cmd,
   if(numbytes < 0)
   {
     PRINT_ERROR("I2C write() returned error %d\n",numbytes);
-    perror( "Error  :" );
+    perror("Error  :");
     return CONTROL_ERROR;
   }
   else if(numbytes != len)
@@ -106,7 +105,7 @@ control_write_command(control_resid_t resid, control_cmd_t cmd,
   if(numbytes < 0)
   {
     PRINT_ERROR("I2C read() returned error %d\n",numbytes);
-    perror( "Error  :" );
+    perror("Error  :");
     return CONTROL_ERROR;
   }
 
@@ -134,14 +133,14 @@ control_read_command(control_resid_t resid, control_cmd_t cmd,
   {
     len = control_build_i2c_data(read_hdr, resid, cmd, payload, payload_len);
     if (len != 3){
-      PRINT_ERROR("building read command section of read_device failed. 'len' should be 3 but is %d\n", len);
+      PRINT_ERROR("Building read command section of read_device failed. 'len' should be 3 but is %d\n", len);
       return CONTROL_ERROR;
     }
   }
 #else
   len = control_build_i2c_data(read_hdr, resid, cmd, payload, payload_len);
   if (len != 3){
-    PRINT_ERROR("building read command section of read_device failed. 'len' should be 3 but is %d\n", len);
+    PRINT_ERROR("Building read command section of read_device failed. 'len' should be 3 but is %d\n", len);
     return CONTROL_ERROR;
   }
 #endif
@@ -173,8 +172,8 @@ control_read_command(control_resid_t resid, control_cmd_t cmd,
   int errno = ioctl( fd, I2C_RDWR, &rdwr_data );
 
   if ( errno < 0 ) {
-    PRINT_ERROR("failed to transfer data, rdwr ioctl error number %d: ", errno );
-    perror( "Error  :" );
+    PRINT_ERROR("Failed to transfer data, rdwr ioctl error number %d: ", errno );
+    perror("Error  :");
     return CONTROL_ERROR;
   }
 

--- a/modules/sw_services/device_control/host/device_access_i2c_rpi.c
+++ b/modules/sw_services/device_control/host/device_access_i2c_rpi.c
@@ -18,6 +18,7 @@
 
 //#define DBG(x) x
 #define DBG(x)
+#define PRINT_ERROR(...)   fprintf(stderr, "Error  : " __VA_ARGS__)
 
 /*Note there is an issue with RPI/Jessie where I2C repeated starts are not enabled by default.
 Try the following at the bash command line to enable them:
@@ -38,13 +39,13 @@ control_ret_t control_init_i2c(unsigned char i2c_slave_address)
   address = i2c_slave_address;
 
   if ((fd = open(devName, O_RDWR)) < 0) {          // Open port for reading and writing
-    fprintf(stderr, "Failed to open i2c port: ");
+    PRINT_ERROR("Failed to open i2c port: ");
     perror( "" );
     return CONTROL_ERROR;
   }
-  
+
   if (ioctl(fd, I2C_SLAVE, address) < 0) {          // Set the port options and set the address of the device we wish to speak to
-    fprintf(stderr, "Unable to set i2c configuration at address 0x%x: ", address);
+    PRINT_ERROR("Unable to set i2c configuration at address 0x%x: ", address);
     perror( "" );
     return CONTROL_ERROR;
   }
@@ -84,16 +85,16 @@ control_write_command(control_resid_t resid, control_cmd_t cmd,
   {
     len = control_build_i2c_data(buffer_to_send, resid, cmd, payload, payload_len);
   }
-#else  
+#else
   len = control_build_i2c_data(buffer_to_send, resid, cmd, payload, payload_len);
 #endif
-  
+
   // Not doing ioctl I2C_RDWR due to the issue seen when write length is a multiple of 12 bytes
   // https://github.com/xmos/sw_xvf3800/issues/314
   int numbytes = write(fd, buffer_to_send, len);
   if(numbytes < 0)
   {
-    printf("I2C write() returned error %d\n",numbytes);
+    PRINT_ERROR("I2C write() returned error %d\n",numbytes);
     perror( "Error  :" );
     return CONTROL_ERROR;
   }
@@ -104,7 +105,7 @@ control_write_command(control_resid_t resid, control_cmd_t cmd,
   numbytes = read(fd, command_status, 1);
   if(numbytes < 0)
   {
-    printf("I2C read() returned error %d\n",numbytes);
+    PRINT_ERROR("I2C read() returned error %d\n",numbytes);
     perror( "Error  :" );
     return CONTROL_ERROR;
   }
@@ -133,14 +134,14 @@ control_read_command(control_resid_t resid, control_cmd_t cmd,
   {
     len = control_build_i2c_data(read_hdr, resid, cmd, payload, payload_len);
     if (len != 3){
-      fprintf(stderr, "Error building read command section of read_device. len should be 3 but is %d\n", len);
+      PRINT_ERROR("building read command section of read_device failed. 'len' should be 3 but is %d\n", len);
       return CONTROL_ERROR;
     }
   }
 #else
   len = control_build_i2c_data(read_hdr, resid, cmd, payload, payload_len);
   if (len != 3){
-    fprintf(stderr, "Error building read command section of read_device. len should be 3 but is %d\n", len);
+    PRINT_ERROR("building read command section of read_device failed. 'len' should be 3 but is %d\n", len);
     return CONTROL_ERROR;
   }
 #endif
@@ -172,7 +173,7 @@ control_read_command(control_resid_t resid, control_cmd_t cmd,
   int errno = ioctl( fd, I2C_RDWR, &rdwr_data );
 
   if ( errno < 0 ) {
-    fprintf(stderr, "Failed to transfer data, rdwr ioctl error number %d: ", errno );
+    PRINT_ERROR("failed to transfer data, rdwr ioctl error number %d: ", errno );
     perror( "Error  :" );
     return CONTROL_ERROR;
   }

--- a/modules/sw_services/device_control/host/device_access_i2c_rpi.c
+++ b/modules/sw_services/device_control/host/device_access_i2c_rpi.c
@@ -45,7 +45,7 @@ control_ret_t control_init_i2c(unsigned char i2c_slave_address)
   }
 
   if (ioctl(fd, I2C_SLAVE, address) < 0) {          // Set the port options and set the address of the device we wish to speak to
-    PRINT_ERROR("Unable to set i2c configuration at address 0x%x: ", address);
+    PRINT_ERROR("unable to set i2c configuration at address 0x%x: ", address);
     perror( "" );
     return CONTROL_ERROR;
   }

--- a/modules/sw_services/device_control/host/device_access_spi_rpi.c
+++ b/modules/sw_services/device_control/host/device_access_spi_rpi.c
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 XMOS LIMITED.
+// Copyright 2017-2024 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 #if USE_SPI && RPI
 

--- a/modules/sw_services/device_control/host/device_access_spi_rpi.c
+++ b/modules/sw_services/device_control/host/device_access_spi_rpi.c
@@ -31,7 +31,7 @@ control_init_spi_pi(spi_mode_t spi_mode, bcm2835SPIClockDivider clock_divider, l
 {
   if(!bcm2835_init() ||
      !bcm2835_spi_begin()) {
-    fprintf(stderr, "BCM2835 initialisation failed. Possibly not running as root\n");
+    PRINT_ERROR("BCM2835 initialisation failed. Possibly not running as root\n");
     return CONTROL_ERROR;
   }
 
@@ -41,7 +41,7 @@ control_init_spi_pi(spi_mode_t spi_mode, bcm2835SPIClockDivider clock_divider, l
   bcm2835_spi_setClockDivider(clock_divider);
   bcm2835_spi_chipSelect(BCM2835_SPI_CS0);
   bcm2835_spi_setChipSelectPolarity(BCM2835_SPI_CS0, LOW);
-	
+
   return CONTROL_SUCCESS;
 }
 control_ret_t
@@ -77,7 +77,7 @@ control_write_command(control_resid_t resid, control_cmd_t cmd,
   {
       // get status
       memset(data_sent_recieved, 0, SPI_TRANSACTION_MAX_BYTES);
-      unsigned transaction_length = payload_len < 8 ? 8 : payload_len;  
+      unsigned transaction_length = payload_len < 8 ? 8 : payload_len;
       bcm2835_spi_transfern((char *)data_sent_recieved, payload_len);
       apply_intertransaction_delay();
   }while(data_sent_recieved[0] == CONTROL_COMMAND_IGNORED_IN_DEVICE);
@@ -112,11 +112,11 @@ control_read_command(control_resid_t resid, control_cmd_t cmd,
       apply_intertransaction_delay();
 
   }while(data_sent_recieved[0] == CONTROL_COMMAND_IGNORED_IN_DEVICE);
-  
+
   do
   {
       memset(data_sent_recieved, 0, SPI_TRANSACTION_MAX_BYTES);
-      unsigned transaction_length = payload_len < 8 ? 8 : payload_len;  
+      unsigned transaction_length = payload_len < 8 ? 8 : payload_len;
 
       bcm2835_spi_transfern((char *)data_sent_recieved, payload_len);
       apply_intertransaction_delay();

--- a/modules/sw_services/device_control/host/device_access_usb.c
+++ b/modules/sw_services/device_control/host/device_access_usb.c
@@ -1,4 +1,4 @@
-// Copyright 2016-2023 XMOS LIMITED.
+// Copyright 2016-2024 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 #if USE_USB
 #include <stdio.h>
@@ -211,7 +211,7 @@ static control_ret_t find_xmos_device(int vendor_id, int product_id)
               (dev->descriptor.idProduct == product_id)) {
         devh = usb_open(dev);
         if (!devh) {
-          PRINT_ERROR("failed to open device\n");
+          PRINT_ERROR("Failed to open device\n");
           return CONTROL_ERROR;
         }
         break;
@@ -220,7 +220,7 @@ static control_ret_t find_xmos_device(int vendor_id, int product_id)
   }
 
   if (!devh) {
-    PRINT_ERROR("could not find device\n");
+    PRINT_ERROR("Could not find device\n");
     return CONTROL_ERROR;
   }
 
@@ -238,14 +238,14 @@ control_ret_t control_init_usb(int vendor_id, int product_id, int interface_num)
 
   int r = usb_set_configuration(devh, 1);
   if (r < 0) {
-    PRINT_ERROR("setting config 1\n");
+    PRINT_ERROR("Setting config 1\n");
     usb_close(devh);
     return CONTROL_ERROR;
   }
 
   r = usb_claim_interface(devh, interface_num);
   if (r < 0) {
-    PRINT_ERROR("claiming interface %d %d\n", interface_num, r);
+    PRINT_ERROR("Claiming interface %d %d\n", interface_num, r);
     return CONTROL_ERROR;
   }
 
@@ -265,7 +265,7 @@ control_ret_t control_init_usb(int vendor_id, int product_id, int interface_num)
 {
   int ret = libusb_init(NULL);
   if (ret < 0) {
-    PRINT_ERROR("failed to initialise libusb\n");
+    PRINT_ERROR("Failed to initialise libusb\n");
     return CONTROL_ERROR;
   }
 
@@ -283,12 +283,12 @@ control_ret_t control_init_usb(int vendor_id, int product_id, int interface_num)
   }
 
   if (dev == NULL) {
-    PRINT_ERROR("could not find device\n");
+    PRINT_ERROR("Could not find device\n");
     return CONTROL_ERROR;
   }
 
   if (libusb_open(dev, &devh) < 0) {
-    PRINT_ERROR("failed to open device. Ensure adequate permissions\n");
+    PRINT_ERROR("Failed to open device. Ensure adequate permissions\n");
     return CONTROL_ERROR;
   }
 

--- a/modules/sw_services/device_control/host/device_access_usb.c
+++ b/modules/sw_services/device_control/host/device_access_usb.c
@@ -21,6 +21,7 @@ typedef enum { false = 0, true = 1} bool;
 
 //#define DBG(x) x
 #define DBG(x)
+#define PRINT_ERROR(...)   fprintf(stderr, "Error  : " __VA_ARGS__)
 
 static unsigned num_commands = 0;
 
@@ -38,11 +39,11 @@ static const int sync_timeout_ms = 500;
 void debug_libusb_error(int err_code)
 {
 #if defined _WIN32
-  printf("libusb_control_transfer returned %s\n", usb_strerror());
+  PRINT_ERROR("libusb_control_transfer returned %s\n", usb_strerror());
 #elif defined __APPLE__
-  printf("libusb_control_transfer returned %s\n", libusb_error_name(err_code));
+  PRINT_ERROR("libusb_control_transfer returned %s\n", libusb_error_name(err_code));
 #elif defined __linux
-  printf("libusb_control_transfer returned %d\n", err_code);
+  PRINT_ERROR("libusb_control_transfer returned %d\n", err_code);
 #endif
 
 }
@@ -210,7 +211,7 @@ static control_ret_t find_xmos_device(int vendor_id, int product_id)
               (dev->descriptor.idProduct == product_id)) {
         devh = usb_open(dev);
         if (!devh) {
-          fprintf(stderr, "failed to open device\n");
+          PRINT_ERROR("failed to open device\n");
           return CONTROL_ERROR;
         }
         break;
@@ -219,7 +220,7 @@ static control_ret_t find_xmos_device(int vendor_id, int product_id)
   }
 
   if (!devh) {
-    fprintf(stderr, "could not find device\n");
+    PRINT_ERROR("could not find device\n");
     return CONTROL_ERROR;
   }
 
@@ -237,14 +238,14 @@ control_ret_t control_init_usb(int vendor_id, int product_id, int interface_num)
 
   int r = usb_set_configuration(devh, 1);
   if (r < 0) {
-    fprintf(stderr, "Error setting config 1\n");
+    PRINT_ERROR("setting config 1\n");
     usb_close(devh);
     return CONTROL_ERROR;
   }
 
   r = usb_claim_interface(devh, interface_num);
   if (r < 0) {
-    fprintf(stderr, "Error claiming interface %d %d\n", interface_num, r);
+    PRINT_ERROR("claiming interface %d %d\n", interface_num, r);
     return CONTROL_ERROR;
   }
 
@@ -264,7 +265,7 @@ control_ret_t control_init_usb(int vendor_id, int product_id, int interface_num)
 {
   int ret = libusb_init(NULL);
   if (ret < 0) {
-    fprintf(stderr, "failed to initialise libusb\n");
+    PRINT_ERROR("failed to initialise libusb\n");
     return CONTROL_ERROR;
   }
 
@@ -282,12 +283,12 @@ control_ret_t control_init_usb(int vendor_id, int product_id, int interface_num)
   }
 
   if (dev == NULL) {
-    fprintf(stderr, "could not find device\n");
+    PRINT_ERROR("could not find device\n");
     return CONTROL_ERROR;
   }
 
   if (libusb_open(dev, &devh) < 0) {
-    fprintf(stderr, "failed to open device. Ensure adequate permissions\n");
+    PRINT_ERROR("failed to open device. Ensure adequate permissions\n");
     return CONTROL_ERROR;
   }
 


### PR DESCRIPTION
This PR port the changes in https://github.com/xmos/lib_device_control/pull/102.
Part of https://xmosjira.atlassian.net/browse/LSM-62

The changes have been used in host_xvf_control in https://github.com/xmos/host_xvf_control/pull/130.