### PR TITLE
removing docker from usb tests, fixing develop issues for multi-com agents

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -161,10 +161,8 @@ pipeline {
                                 withTools(params.TOOLS_VERSION) {
                                     withVenv {
                                         script {
-                                            uid = sh(returnStdout: true, script: 'id -u').trim()
-                                            gid = sh(returnStdout: true, script: 'id -g').trim()
                                             withXTAG(["$RTOS_TEST_RIG_TARGET"]) { adapterIDs ->
-                                                sh "docker run --rm -u $uid:$gid --privileged -v /dev:/dev -w /fwk_rtos -v $WORKSPACE:/fwk_rtos ghcr.io/xmos/xcore_voice_tester:develop bash -l test/rtos_drivers/usb/check_usb.sh " + adapterIDs[0]
+                                                sh "bash -l test/rtos_drivers/usb/check_usb.sh" + adapterIDs[0]
                                             }
                                             sh "pytest test/rtos_drivers/usb"
                                         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -78,7 +78,7 @@ pipeline {
                         expression { !env.GH_LABEL_DOC_ONLY.toBoolean() }
                     }
                     agent {
-                        label 'sw-hw-xcai-exp1' //TODO remove this label to previous one!!!
+                        label 'xcore.ai-explorer-hil-tests'
                     }
                     stages {
                         stage('Checkout') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -78,7 +78,7 @@ pipeline {
                         expression { !env.GH_LABEL_DOC_ONLY.toBoolean() }
                     }
                     agent {
-                        label 'xcore.ai-explorer-hil-tests'
+                        label 'sw-hw-xcai-exp1' //TODO remove this label to previous one!!!
                     }
                     stages {
                         stage('Checkout') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -60,6 +60,7 @@ pipeline {
                         runningOn(env.NODE_NAME)
                         dir('fwk_rtos'){
                             checkout scm
+                            createVenv()
                             withTools(params.TOOLS_VERSION) {
                                 buildDocs("fwk_rtos_docs.zip")
                             } // withTools

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -168,7 +168,7 @@ pipeline {
                                     withVenv {
                                         script {
                                             withXTAG(["$RTOS_TEST_RIG_TARGET"]) { adapterIDs ->
-                                                sh "bash -l test/rtos_drivers/usb/check_usb.sh" + adapterIDs[0]
+                                                sh "bash -l test/rtos_drivers/usb/check_usb.sh " + adapterIDs[0]
                                             }
                                             sh "pytest test/rtos_drivers/usb"
                                         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,10 @@
 @Library('xmos_jenkins_shared_library@v0.28.0') _
 
+def runningOn(machine) {
+  println "Stage running on:"
+  println machine
+}
+
 getApproval()
 
 pipeline {
@@ -69,6 +74,7 @@ pipeline {
                     stages {
                         stage('Checkout') {
                             steps {
+                                runningOn(env.NODE_NAME)
                                 checkout scm
                                 sh 'git submodule update --init --recursive --depth 1 --jobs \$(nproc)'
                             }

--- a/test/rtos_drivers/usb/serial_send_receive.py
+++ b/test/rtos_drivers/usb/serial_send_receive.py
@@ -35,7 +35,7 @@ def find_ports_by_vid_pid(rq=2, msg="COM ports missing"):
     all_ports = serial.tools.list_ports.comports()
     test_ports = [port for port in all_ports if port.vid == vid and port.pid == pid]
     assert (len(test_ports) >= rq), msg
-    test_ports=test_ports[:rq]
+    test_ports=test_ports[0:rq] # TODO needs to be choosen more intelligently
     return test_ports
 
 def transfer_data(input_file, output_file, write_port, read_port, max_read_size):

--- a/test/rtos_drivers/usb/serial_send_receive.py
+++ b/test/rtos_drivers/usb/serial_send_receive.py
@@ -35,7 +35,6 @@ def find_ports_by_vid_pid(rq=2, msg="COM ports missing"):
     all_ports = serial.tools.list_ports.comports()
     test_ports = [port for port in all_ports if port.vid == vid and port.pid == pid]
     assert (len(test_ports) >= rq), msg
-    test_ports=test_ports[0:rq] # TODO needs to be choosen more intelligently
     return test_ports
 
 def transfer_data(input_file, output_file, write_port, read_port, max_read_size):
@@ -53,12 +52,15 @@ def main(if0, if1, of0, of1):
     port0 = None
     port1 = None
         
-    try:    
-        print(f'Opening port 0 ({test_ports[0].device}).')
-        port0 = serial.Serial(test_ports[0].device)
+    try:
+        d0 = test_ports[0].device
+        d1 = test_ports[1].device
+
+        print(f'Opening port 0 ({d0}).')
+        port0 = serial.Serial(d0)
         
-        print(f'Opening port 1 ({test_ports[1].device}).')
-        port1 = serial.Serial(test_ports[1].device)
+        print(f'Opening port 1 ({d1}).')
+        port1 = serial.Serial(d1)
 
         print('Writing CDC test data to port 0, reading from port 1.')
         transfer_data(if0, of1, port0, port1, max_read_size)

--- a/test/rtos_drivers/usb/test_verify_usb_results.py
+++ b/test/rtos_drivers/usb/test_verify_usb_results.py
@@ -10,6 +10,8 @@ target_test_regex = r"^Tile\[(\d{1})\]\|FCore\[(\d{1})\]\|(\d+)\|TEST\|(\w{4}) U
 host_test_results_filename = "testing/host.rpt"
 host_test_regex = r"^\[TEST PASS\]:"
 
+required_ports = 2
+
 def test_results():
     with open(target_test_results_filename, "r") as f:
         cnt = 0
@@ -17,7 +19,8 @@ def test_results():
             line = f.readline()
 
             if not line:
-                assert cnt == 2 # each tile should report PASS
+                # each tile should report PASS
+                assert cnt == required_ports, f"cnt = {cnt}"
                 break
 
             p = re.match(target_test_regex, line)
@@ -39,3 +42,7 @@ def test_results():
 
             if p:
                 cnt += 1
+
+
+if __name__ == "__main__":
+    test_results() # manual debug

--- a/test/rtos_drivers/usb/test_verify_usb_results.py
+++ b/test/rtos_drivers/usb/test_verify_usb_results.py
@@ -3,45 +3,39 @@
 # This Software is subject to the terms of the XMOS Public Licence: Version 1.
 
 import re
+from pathlib import Path
 
-target_test_results_filename = "testing/target.rpt"
-target_test_regex = r"^Tile\[(\d{1})\]\|FCore\[(\d{1})\]\|(\d+)\|TEST\|(\w{4}) USB$"
+top_level = Path(__file__).parents[3].absolute() # if changes, make sure this relative path is correct
 
-host_test_results_filename = "testing/host.rpt"
+target_test_results_filename = top_level / "testing/target.rpt"
+target_test_regex = r"^Tile\[\d\]\|FCore\[\d\]\|\d+\|TEST\|PASS USB$"
+target_test_required_count = 2
+
+host_test_results_filename = top_level / "testing/host.rpt"
 host_test_regex = r"^\[TEST PASS\]:"
+host_test_required_count = 1
 
-required_ports = 2
+
+def validate_results(filename, regex, required_count):
+    """Counts the number of matching eleements in a file given a regex
+
+    Args:
+        filename (str): path to the file
+        regex (regex): regex expression
+        required_count (int): number of elements expected
+    """
+    with open(filename, "r") as file:
+        content = file.read()
+    
+    matches = re.findall(regex, content, re.MULTILINE)
+    pass_count = len(matches)
+
+    assert pass_count == required_count, f"Expected {required_count} passes, but found {pass_count}"
+
 
 def test_results():
-    with open(target_test_results_filename, "r") as f:
-        cnt = 0
-        while 1:
-            line = f.readline()
-
-            if not line:
-                # each tile should report PASS
-                assert cnt == required_ports, f"cnt = {cnt}"
-                break
-
-            p = re.match(target_test_regex, line)
-
-            if p:
-                cnt += 1
-                assert p.group(4).find("PASS") != -1
-
-    with open(host_test_results_filename, "r") as f:
-        cnt = 0
-        while 1:
-            line = f.readline()
-
-            if not line:
-                assert cnt == 1
-                break
-
-            p = re.match(host_test_regex, line)
-
-            if p:
-                cnt += 1
+    validate_results(target_test_results_filename, target_test_regex, target_test_required_count)
+    validate_results(host_test_results_filename, host_test_regex, host_test_required_count)
 
 
 if __name__ == "__main__":

--- a/test/rtos_drivers/usb/test_verify_usb_results.py
+++ b/test/rtos_drivers/usb/test_verify_usb_results.py
@@ -42,3 +42,4 @@ def test_results():
 
 if __name__ == "__main__":
     test_results() # manual debug
+    

--- a/test/rtos_drivers/usb/test_verify_usb_results.py
+++ b/test/rtos_drivers/usb/test_verify_usb_results.py
@@ -17,7 +17,7 @@ host_test_required_count = 1
 
 
 def validate_results(filename, regex, required_count):
-    """Counts the number of matching eleements in a file given a regex
+    """Counts the number of matching elements in a file given a regex
 
     Args:
         filename (str): path to the file

--- a/test/rtos_drivers/usb/test_verify_usb_results.py
+++ b/test/rtos_drivers/usb/test_verify_usb_results.py
@@ -18,6 +18,7 @@ host_test_required_count = 1
 
 def validate_results(filename, regex, required_count):
     """Counts the number of matching elements in a file given a regex
+    and ensures mathes the required count, will raise an exception if not. 
 
     Args:
         filename (str): path to the file
@@ -31,6 +32,7 @@ def validate_results(filename, regex, required_count):
     pass_count = len(matches)
 
     assert pass_count == required_count, f"Expected {required_count} passes, but found {pass_count}"
+    return pass_count
 
 
 def test_results():


### PR DESCRIPTION
Closes: [LSM-41](https://xmosjira.atlassian.net/browse/LSM-41?atlOrigin=eyJpIjoiZDZjYTNjYmU4MzcyNGY1MjkwNmI4MDNlODBmZTQ4ODIiLCJwIjoiaiJ9)

More info about this PR/issue here (recommended): [confluence](https://xmosjira.atlassian.net/wiki/spaces/~63ce65618dd199a03e109b44/pages/4141383681) 

- Removing docker from stage: Run RTOS Drivers USB test
- Removing docker from stage: build docs
- Cleaning up python scripts:
   -  test/rtos_drivers/usb/serial_send_receive.py. assert if less COM ports than required
   - test/rtos_drivers/usb/test_verify_usb_results.py: refactor to simplify scripts, avoid while(1). 
- Use serial number for dfu tests

[LSM-41]: https://xmosjira.atlassian.net/browse/LSM-41?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ