### PR TITLE
Remove flash info from .xn files.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ RTOS Framework change log
   * ADDED: Support for MSOS2.0 descriptor to automatically assign the WinUSB drivers to the DFU interface
     during enumeration on Windows. This enhancement is included in the USB descriptors of the USB tests.
   * ADDED: Support for multiread and multiwrite functions to the I2C master drivers.
+  * FIXED: Removed flash info from .xn files due to tools SFDP integration. 
 
 3.2.0
 -----

--- a/test/rtos_drivers/clock_control/XCORE-AI-EXPLORER.xn
+++ b/test/rtos_drivers/clock_control/XCORE-AI-EXPLORER.xn
@@ -100,7 +100,7 @@
     </Link>
   </Links>
   <ExternalDevices>
-    <Device NodeId="0" Tile="0" Class="SQIFlash" Name="bootFlash" Type="S25FL116K" PageSize="256" SectorSize="4096" NumPages="16384">
+    <Device NodeId="0" Tile="0" Class="SQIFlash" Name="bootFlash">
       <Attribute Name="PORT_SQI_CS" Value="PORT_SQI_CS"/>
       <Attribute Name="PORT_SQI_SCLK"   Value="PORT_SQI_SCLK"/>
       <Attribute Name="PORT_SQI_SIO"  Value="PORT_SQI_SIO"/>

--- a/test/rtos_drivers/hil/XCORE-AI-EXPLORER.xn
+++ b/test/rtos_drivers/hil/XCORE-AI-EXPLORER.xn
@@ -100,7 +100,7 @@
     </Link>
   </Links>
   <ExternalDevices>
-    <Device NodeId="0" Tile="0" Class="SQIFlash" Name="bootFlash" Type="S25FL116K" PageSize="256" SectorSize="4096" NumPages="16384">
+    <Device NodeId="0" Tile="0" Class="SQIFlash" Name="bootFlash">
       <Attribute Name="PORT_SQI_CS" Value="PORT_SQI_CS"/>
       <Attribute Name="PORT_SQI_SCLK"   Value="PORT_SQI_SCLK"/>
       <Attribute Name="PORT_SQI_SIO"  Value="PORT_SQI_SIO"/>

--- a/test/rtos_drivers/hil_add/XCORE-AI-EXPLORER.xn
+++ b/test/rtos_drivers/hil_add/XCORE-AI-EXPLORER.xn
@@ -100,7 +100,7 @@
     </Link>
   </Links>
   <ExternalDevices>
-    <Device NodeId="0" Tile="0" Class="SQIFlash" Name="bootFlash" Type="S25FL116K" PageSize="256" SectorSize="4096" NumPages="16384">
+    <Device NodeId="0" Tile="0" Class="SQIFlash" Name="bootFlash">
       <Attribute Name="PORT_SQI_CS" Value="PORT_SQI_CS"/>
       <Attribute Name="PORT_SQI_SCLK"   Value="PORT_SQI_SCLK"/>
       <Attribute Name="PORT_SQI_SIO"  Value="PORT_SQI_SIO"/>

--- a/test/rtos_drivers/usb/XCORE-AI-EXPLORER.xn
+++ b/test/rtos_drivers/usb/XCORE-AI-EXPLORER.xn
@@ -100,7 +100,7 @@
     </Link>
   </Links>
   <ExternalDevices>
-    <Device NodeId="0" Tile="0" Class="SQIFlash" Name="bootFlash" Type="S25FL116K" PageSize="256" SectorSize="4096" NumPages="16384">
+    <Device NodeId="0" Tile="0" Class="SQIFlash" Name="bootFlash">
       <Attribute Name="PORT_SQI_CS" Value="PORT_SQI_CS"/>
       <Attribute Name="PORT_SQI_SCLK"   Value="PORT_SQI_SCLK"/>
       <Attribute Name="PORT_SQI_SIO"  Value="PORT_SQI_SIO"/>

--- a/test/rtos_drivers/wifi/XCORE-AI-EXPLORER.xn
+++ b/test/rtos_drivers/wifi/XCORE-AI-EXPLORER.xn
@@ -100,7 +100,7 @@
     </Link>
   </Links>
   <ExternalDevices>
-    <Device NodeId="0" Tile="0" Class="SQIFlash" Name="bootFlash" Type="S25FL116K" PageSize="256" SectorSize="4096" NumPages="16384">
+    <Device NodeId="0" Tile="0" Class="SQIFlash" Name="bootFlash">
       <Attribute Name="PORT_SQI_CS" Value="PORT_SQI_CS"/>
       <Attribute Name="PORT_SQI_SCLK"   Value="PORT_SQI_SCLK"/>
       <Attribute Name="PORT_SQI_SIO"  Value="PORT_SQI_SIO"/>


### PR DESCRIPTION
From [LSM-104](https://xmosjira.atlassian.net/browse/LSM-104).

Removes the flash info from .xn files due to the integration of SFDP into tools.

[LSM-104]: https://xmosjira.atlassian.net/browse/LSM-104?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ